### PR TITLE
NL-48 Extend news creationDate to save creationTime too

### DIFF
--- a/src/main/java/erkamber/dtos/NewsDetailedDto.java
+++ b/src/main/java/erkamber/dtos/NewsDetailedDto.java
@@ -5,7 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.*;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -40,7 +40,7 @@ public class NewsDetailedDto {
     private int numberOfViews;
 
     @NotNull(message = "News Creation Date cannot be Null")
-    private LocalDate newsCreationDate;
+    private LocalDateTime newsCreationDate;
 
     private List<TagDto> listOfNewsTags;
 

--- a/src/main/java/erkamber/dtos/NewsDto.java
+++ b/src/main/java/erkamber/dtos/NewsDto.java
@@ -3,13 +3,8 @@ package erkamber.dtos;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
-import javax.validation.constraints.Size;
-import java.time.LocalDate;
+import javax.validation.constraints.*;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -39,14 +34,14 @@ public class NewsDto {
     @PositiveOrZero(message = "Down votes must be Positive number or Zero")
     private int newsDownVotes;
 
-    private LocalDate newsCreationDate;
+    private LocalDateTime newsCreationDate;
 
     public NewsDto() {
     }
 
     public NewsDto(
             int userID, String newsTitle, String newsContent, int newsUpVotes, int newsDownVotes,
-            LocalDate newsCreationDate) {
+            LocalDateTime newsCreationDate) {
         this.userID = userID;
         this.newsTitle = newsTitle;
         this.newsContent = newsContent;
@@ -71,7 +66,7 @@ public class NewsDto {
 
     public NewsDto(
             int newsID, int userID, String newsTitle, String newsContent, int newsUpVotes, int newsDownVotes,
-            LocalDate newsCreationDate) {
+            LocalDateTime newsCreationDate) {
         this.newsID = newsID;
         this.userID = userID;
         this.newsTitle = newsTitle;

--- a/src/main/java/erkamber/entities/News.java
+++ b/src/main/java/erkamber/entities/News.java
@@ -5,6 +5,7 @@ import lombok.Setter;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
@@ -34,13 +35,13 @@ public class News {
     private int newsDownVotes;
 
     @Column(name = "news_creation_date", unique = false, updatable = false, insertable = true, nullable = false)
-    private LocalDate newsCreationDate;
+    private LocalDateTime newsCreationDate;
 
     public News() {
     }
 
     public News(int newsID, int userID, String newsTitle, String newsContent, int newsUpVotes, int newsDownVotes,
-                LocalDate newsCreationDate) {
+                LocalDateTime newsCreationDate) {
 
         this.newsID = newsID;
         this.userID = userID;

--- a/src/main/java/erkamber/services/implementations/NewsServiceImpl.java
+++ b/src/main/java/erkamber/services/implementations/NewsServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -151,7 +152,9 @@ public class NewsServiceImpl implements NewsService {
     @Override
     public int addNews(NewsDto newsDto) {
 
-        newsDto.setNewsCreationDate(LocalDate.now());
+        LocalDateTime localDateTime = LocalDateTime.now();
+
+        newsDto.setNewsCreationDate(localDateTime);
 
         isUserExists(newsDto.getUserID());
 


### PR DESCRIPTION
## Pull Request Description

### Description

Extend news creation Date to save creation Time too

### Trello

Trello Ticket: https://trello.com/c/egyWwz5f

### Additional Notes

Local and Remote DBs should be dropped and created newly, in order hibernate to create new column with new type for creation Date and Time of news
